### PR TITLE
Throw IllegalArgumentException if last key of sorted-map has no val

### DIFF
--- a/src/clj/avl/clj.clj
+++ b/src/clj/avl/clj.clj
@@ -1207,7 +1207,10 @@
   [& keyvals]
   (loop [in (seq keyvals) out (transient empty-map)]
     (if in
-      (recur (nnext in) (assoc! out (first in) (second in)))
+      (if (next in)
+        (recur (nnext in) (assoc! out (first in) (second in)))
+        (throw (IllegalArgumentException.
+                "sorted-map expects even number of arguments, found odd number")))
       (persistent! out))))
 
 (defn sorted-map-by
@@ -1219,7 +1222,10 @@
          out (AVLTransientMap.
               (AtomicReference. (Thread/currentThread)) comparator nil 0)]
     (if in
-      (recur (nnext in) (assoc! out (first in) (second in)))
+      (if (next in)
+        (recur (nnext in) (assoc! out (first in) (second in)))
+        (throw (IllegalArgumentException.
+                "sorted-map expects even number of arguments, found odd number")))
       (persistent! out))))
 
 (defn sorted-set

--- a/test/clj/avl/clj_test.clj
+++ b/test/clj/avl/clj_test.clj
@@ -41,3 +41,10 @@
     (is (every? true? (map = ks (map #(key (nth avl-map %)) ks)))))
   (testing "set rank queries work as expected"
     (is (every? true? (map = ks (map #(nth avl-set %) ks))))))
+
+(deftest bad-args
+  (testing "sorted-map and sorted-map-by expect val for every key"
+    (is (thrown? IllegalArgumentException
+                 (avl/sorted-map [:a 1 :b])))
+    (is (thrown? IllegalArgumentException
+                 (avl/sorted-map-by < [1 :a 2])))))


### PR DESCRIPTION
Similar to error checking now done in Clojure as a result of CLJ-1052.
clojure.core/sorted-map and clojure.core/sorted-map-by also throw
exceptions in this case.
